### PR TITLE
Add `$schema` to `cgmanifest.json`

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1,122 +1,124 @@
 {
-    "Registrations": [ 
-        {
-            "Component": { 
-                "Type": "git", 
-                "Git": {
-                    "RepositoryUrl": "https://github.com/clab/fast_align",
-                    "CommitHash": "cab1e9aac8d3bb02ff5ae58218d8d225a039fa11"
-                }
-            },
-            "DevelopmentDependency": false
-        },
-        {
-            "Component": { 
-                "Type": "other", 
-                "Other": {
-                    "Name": "Stanford Parser",
-                    "Version": "3.8.0",
-                    "DownloadUrl": "https://nlp.stanford.edu/software/stanford-parser-full-2017-06-09.zip" 
-                }
-            },
-            "DevelopmentDependency": false
-        },
-        {
-            "Component": { 
-                "Type": "other", 
-                "Other": {
-                    "Name": "rsvg-convert",
-                    "Version": "2.40.20",
-                    "DownloadUrl": "https://launchpad.net/ubuntu/bionic/+package/librsvg2-bin" 
-                }
-            },
-            "DevelopmentDependency": false
-        },
-        {
-            "Component": { 
-                "Type": "other", 
-                "Other": {
-                    "Name": "NFAtoDFA",
-                    "Version": "2 October 2015",
-                    "DownloadUrl": "stefanmendoza.dev@gmail.com" 
-                }
-            },
-            "DevelopmentDependency": false
-        },
-        {
-            "Component": { 
-                "Type": "other", 
-                "Other": {
-                    "Name": "jQuery",
-                    "Version": "3.5.1",
-                    "DownloadUrl": "https://jquery.com/download/" 
-                }
-            },
-            "DevelopmentDependency": false
-        },
-        {
-            "Component": { 
-                "Type": "other", 
-                "Other": {
-                    "Name": "Bootstrap",
-                    "Version": "5.0.0-beta2",
-                    "DownloadUrl": "https://getbootstrap.com/docs/5.0/getting-started/download/" 
-                }
-            },
-            "DevelopmentDependency": false
-        },
-        {
-            "Component": { 
-                "Type": "other", 
-                "Other": {
-                    "Name": "Select2",
-                    "Version": "4.1.0-rc.0",
-                    "DownloadUrl": "https://select2.org/getting-started/installation" 
-                }
-            },
-            "DevelopmentDependency": false
-        },
-        {
-            "Component": { 
-                "Type": "other", 
-                "Other": {
-                    "Name": "JQuery Dropdown",
-                    "Version": "2.0.3",
-                    "DownloadUrl": "https://github.com/soundasleep/jquery-dropdown" 
-                }
-            },
-            "DevelopmentDependency": false
-        },
-        {
-            "Component": { 
-                "Type": "other", 
-                "Other": {
-                    "Name": "Bootstrap Maxlength",
-                    "Version": "v1.10.0",
-                    "DownloadUrl": "https://github.com/mimo84/bootstrap-maxlength" 
-                }
-            },
-            "DevelopmentDependency": false
-        },
-        {
-            "Component": { 
-                "Type": "other", 
-                "Other": {
-                    "Name": "Font Awesome",
-                    "Version": "5.15.2",
-                    "DownloadUrl": "https://fontawesome.com/download" 
-                }
-            },
-            "DevelopmentDependency": false
-        },        {
-            "Component": { 
-                "Type": "git", 
-                "Git": {
-                    "RepositoryUrl": "https://github.com/reverie/python-automata",
-                    "CommitHash": "8b3929a79489045ddab0733bc388809aacaebdb7"
-                }
-            },
-            "DevelopmentDependency": false
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
+    {
+      "Component": {
+        "Type": "git",
+        "Git": {
+          "RepositoryUrl": "https://github.com/clab/fast_align",
+          "CommitHash": "cab1e9aac8d3bb02ff5ae58218d8d225a039fa11"
         }
-    ]
+      },
+      "DevelopmentDependency": false
+    },
+    {
+      "Component": {
+        "Type": "other",
+        "Other": {
+          "Name": "Stanford Parser",
+          "Version": "3.8.0",
+          "DownloadUrl": "https://nlp.stanford.edu/software/stanford-parser-full-2017-06-09.zip"
+        }
+      },
+      "DevelopmentDependency": false
+    },
+    {
+      "Component": {
+        "Type": "other",
+        "Other": {
+          "Name": "rsvg-convert",
+          "Version": "2.40.20",
+          "DownloadUrl": "https://launchpad.net/ubuntu/bionic/+package/librsvg2-bin"
+        }
+      },
+      "DevelopmentDependency": false
+    },
+    {
+      "Component": {
+        "Type": "other",
+        "Other": {
+          "Name": "NFAtoDFA",
+          "Version": "2 October 2015",
+          "DownloadUrl": "stefanmendoza.dev@gmail.com"
+        }
+      },
+      "DevelopmentDependency": false
+    },
+    {
+      "Component": {
+        "Type": "other",
+        "Other": {
+          "Name": "jQuery",
+          "Version": "3.5.1",
+          "DownloadUrl": "https://jquery.com/download/"
+        }
+      },
+      "DevelopmentDependency": false
+    },
+    {
+      "Component": {
+        "Type": "other",
+        "Other": {
+          "Name": "Bootstrap",
+          "Version": "5.0.0-beta2",
+          "DownloadUrl": "https://getbootstrap.com/docs/5.0/getting-started/download/"
+        }
+      },
+      "DevelopmentDependency": false
+    },
+    {
+      "Component": {
+        "Type": "other",
+        "Other": {
+          "Name": "Select2",
+          "Version": "4.1.0-rc.0",
+          "DownloadUrl": "https://select2.org/getting-started/installation"
+        }
+      },
+      "DevelopmentDependency": false
+    },
+    {
+      "Component": {
+        "Type": "other",
+        "Other": {
+          "Name": "JQuery Dropdown",
+          "Version": "2.0.3",
+          "DownloadUrl": "https://github.com/soundasleep/jquery-dropdown"
+        }
+      },
+      "DevelopmentDependency": false
+    },
+    {
+      "Component": {
+        "Type": "other",
+        "Other": {
+          "Name": "Bootstrap Maxlength",
+          "Version": "v1.10.0",
+          "DownloadUrl": "https://github.com/mimo84/bootstrap-maxlength"
+        }
+      },
+      "DevelopmentDependency": false
+    },
+    {
+      "Component": {
+        "Type": "other",
+        "Other": {
+          "Name": "Font Awesome",
+          "Version": "5.15.2",
+          "DownloadUrl": "https://fontawesome.com/download"
+        }
+      },
+      "DevelopmentDependency": false
+    },
+    {
+      "Component": {
+        "Type": "git",
+        "Git": {
+          "RepositoryUrl": "https://github.com/reverie/python-automata",
+          "CommitHash": "8b3929a79489045ddab0733bc388809aacaebdb7"
+        }
+      },
+      "DevelopmentDependency": false
+    }
+  ]
 }


### PR DESCRIPTION
This pull request adds the JSON schema for `cgmanifest.json`.

## FAQ

### Why?

A JSON schema helps you to ensure that your `cgmanifest.json` file is valid.
JSON schema validation is a build-in feature in most modern IDEs like Visual Studio and Visual Studio Code.
Most modern IDEs also provide code-completion for JSON schemas.

### How can I validate my `cgmanifest.json` file?

Most modern IDEs like Visual Studio and Visual Studio Code have a built-in feature to validate JSON files.
You can also use [this small script](https://github.com/JamieMagee/verify-cgmanifest) to validate your `cgmanifest.json` file.

### Why does it suggest camel case for the properties?

Component Detection is able to read camel case and pascal case properties.
However, the JSON schema doesn't have a case-insensitive mode.
We therefore suggest camel case as it's the most common format for JSON.

### Why is the diff so large?

To deserialize the `cgmanifest.json` file, we use [`JSON.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
However, to serialize the JSON again we use [`prettier`](https://prettier.io/).
We found that, in general, it gave smaller diffs than the default [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) function.